### PR TITLE
fix: strip errorCorrection prop from qrcode svg element

### DIFF
--- a/.changeset/sixty-cobras-repair.md
+++ b/.changeset/sixty-cobras-repair.md
@@ -2,4 +2,4 @@
 "cuer": patch
 ---
 
-Prevents React warning by removing the unintended forwarding of the `errorCorrection` prop to SVG elements used by the QRCode component.
+Fixed unintended forwarding of the `errorCorrection` prop to SVG elements used by the QRCode component to prevent React warning.

--- a/.changeset/sixty-cobras-repair.md
+++ b/.changeset/sixty-cobras-repair.md
@@ -1,0 +1,5 @@
+---
+"cuer": patch
+---
+
+Prevents React warning by removing the unintended forwarding of the `errorCorrection` prop to SVG elements used by the QRCode component.

--- a/src/Cuer.tsx
+++ b/src/Cuer.tsx
@@ -83,7 +83,14 @@ export namespace Cuer {
    * @returns A {@link React.ReactNode}
    */
   export function Root(props: Root.Props) {
-    const { children, size = '100%', value, version, ...rest } = props
+    const {
+      children,
+      size = '100%',
+      value,
+      version,
+      errorCorrection,
+      ...rest
+    } = props
 
     // Check if the children contain an `Arena` component.
     const hasArena = React.useMemo(
@@ -105,14 +112,14 @@ export namespace Cuer {
 
     // Create the QR code.
     const qrcode = React.useMemo(() => {
-      let errorCorrection = props.errorCorrection
+      let ecl = errorCorrection
       // If the QR code has an arena, use a higher error correction level.
-      if (hasArena && errorCorrection === 'low') errorCorrection = 'medium'
+      if (hasArena && errorCorrection === 'low') ecl = 'medium'
       return QrCode.create(value, {
-        errorCorrection,
+        errorCorrection: ecl,
         version,
       })
-    }, [value, hasArena, props.errorCorrection, version])
+    }, [value, hasArena, errorCorrection, version])
 
     const cellSize = 1
     const edgeSize = qrcode.edgeLength * cellSize


### PR DESCRIPTION
Stripping `errorCorrection` prop leaking to root SVG element to resolve:

> React does not recognize the `errorCorrection` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `errorcorrection` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

<img width="1071" alt="Screenshot 2025-06-12 at 12 21 34 AM" src="https://github.com/user-attachments/assets/65eb7d98-6ab1-4221-89fd-681b5740646f" />

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/ox/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Ox!
----------------------------------------------------------------------->

