### PR TITLE
fix: prevent sub-pixel values for Arena padding

### DIFF
--- a/src/Cuer.tsx
+++ b/src/Cuer.tsx
@@ -385,7 +385,7 @@ export namespace Cuer {
 
     const start = Math.ceil(edgeSize / 2 - arenaSize / 2)
     const size = arenaSize + (arenaSize % 2)
-    const padding = cellSize / 2
+    const padding = Math.max(Math.ceil(cellSize / 2), 1)
 
     return (
       <foreignObject x={start} y={start} width={size} height={size}>


### PR DESCRIPTION
I'm experiencing Arena `padding` values of e.g. `0.5px`, which causes rendering bugs ultimately causing the arena image to be rendered "off-center".

This PR does the following:
1. Ensures that the Arena `padding` is at least `1px`
2. Rounds `padding` values up to the nearest integer (could've rounded down, but noticed you used `Math.ceil` elsewhere)